### PR TITLE
Fix: Java 18+ Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
       contents: read  # for actions/checkout to fetch code
     name: "${{ matrix.root-pom }} on JDK ${{ matrix.java }} on ${{ matrix.os }}"
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
+        java: [ 8, 11, 17, 21 ]
         root-pom: [ 'pom.xml', 'android/pom.xml' ]
         include:
           - os: windows-latest
-            java: 17
+            java: 21
             root-pom: pom.xml
     runs-on: ${{ matrix.os }}
     env:
@@ -68,11 +69,10 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           server-id: sonatype-nexus-snapshots
           server-username: CI_DEPLOY_USERNAME
@@ -94,11 +94,10 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
       - name: 'Generate latest docs'

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -25,6 +25,7 @@
     <project.build.outputTimestamp>2024-01-02T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.add.opens></test.add.opens>
+    <test.add.args></test.add.args>
     <module.status>integration</module.status>
     <variant.jvmEnvironment>android</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>android</variant.jvmEnvironmentVariantName>
@@ -253,7 +254,7 @@
             <runOrder>alphabetical</runOrder>
             <!-- Set max heap for tests. -->
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
-            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.opens}</argLine>
+            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.args} ${test.add.opens}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -355,6 +356,19 @@
       </activation>
       <properties>
         <maven-javadoc-plugin.additionalJOptions>--no-module-directories</maven-javadoc-plugin.additionalJOptions>
+      </properties>
+    </profile>
+    <profile>
+      <!--
+          In order to build against JDK 19+, Javadoc needs to enable Java preview features, because JDK sources
+          themselves have code which defines/uses preview features.
+       -->
+      <id>javadocs-jdk19plus</id>
+      <activation>
+        <jdk>[19,]</jdk>
+      </activation>
+      <properties>
+        <maven-javadoc-plugin.additionalJOptions>--enable-preview</maven-javadoc-plugin.additionalJOptions>
       </properties>
     </profile>
     <profile>
@@ -461,6 +475,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>javac-for-jvm18plus</id>
+      <activation>
+        <!--
+            In order to build and run the tests against JDK 19+, we need to pass java.security.manager=allow, to make
+            the deprecated 'java.lang.SecurityManager' available for use.
+         -->
+        <jdk>[18,]</jdk>
+      </activation>
+      <properties>
+        <test.add.args>-Djava.security.manager=allow</test.add.args>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -199,6 +199,7 @@
             <link>https://errorprone.info/api/latest/</link>
           </links>
           <overview>../overview.html</overview>
+          <additionalJOption>${maven-javadoc-plugin.additionalJOptions}</additionalJOption>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <project.build.outputTimestamp>2024-01-02T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.add.opens></test.add.opens>
+    <test.add.args></test.add.args>
     <module.status>integration</module.status>
     <variant.jvmEnvironment>standard-jvm</variant.jvmEnvironment>
     <variant.jvmEnvironmentVariantName>jre</variant.jvmEnvironmentVariantName>
@@ -177,6 +178,13 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
           <version>1.23</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>9.6</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <annotations>com.google.common.base.IgnoreJRERequirement,com.google.common.collect.IgnoreJRERequirement,com.google.common.hash.IgnoreJRERequirement,com.google.common.io.IgnoreJRERequirement,com.google.common.reflect.IgnoreJRERequirement,com.google.common.testing.IgnoreJRERequirement</annotations>
             <checkTestClasses>true</checkTestClasses>
@@ -248,7 +256,7 @@
             <runOrder>alphabetical</runOrder>
             <!-- Set max heap for tests. -->
             <!-- Catch dependencies on the default locale by setting it to hi-IN. -->
-            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.opens}</argLine>
+            <argLine>-Xmx1536M -Duser.language=hi -Duser.country=IN ${test.add.args} ${test.add.opens}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -350,6 +358,19 @@
       </activation>
       <properties>
         <maven-javadoc-plugin.additionalJOptions>--no-module-directories</maven-javadoc-plugin.additionalJOptions>
+      </properties>
+    </profile>
+    <profile>
+      <!--
+          In order to build against JDK 19+, Javadoc needs to enable Java preview features, because JDK sources
+          themselves have code which defines/uses preview features.
+       -->
+      <id>javadocs-jdk19plus</id>
+      <activation>
+        <jdk>[19,]</jdk>
+      </activation>
+      <properties>
+        <maven-javadoc-plugin.additionalJOptions>--enable-preview</maven-javadoc-plugin.additionalJOptions>
       </properties>
     </profile>
     <profile>
@@ -456,6 +477,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>javac-for-jvm18plus</id>
+      <activation>
+        <!--
+            In order to build and run the tests against JDK 19+, we need to pass java.security.manager=allow, to make
+            the deprecated 'java.lang.SecurityManager' available for use.
+         -->
+        <jdk>[18,]</jdk>
+      </activation>
+      <properties>
+        <test.add.args>-Djava.security.manager=allow</test.add.args>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Summary

Amends the build to be compatible with JDKs newer than 18.

> [!NOTE]
> This PR is under testing before it is ultimately filed against `google/guava`.

## Changelog

- fix: build against embedded jdk sources needs `--enable-preview` when built against jvm21
- fix: add `-Djava.security.manager=allow` to fix security manager tests under modern java
