### PR TITLE
chore(ci): improvements to gha workflows

### DIFF
--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -1,3 +1,24 @@
+# Guava GitHub CI
+# ---------------------------------------------------------------------------------------------------------------------
+# This is the main CI build on GitHub for the Google Guava project. This workflow is not invoked directly; instead, the
+# `on.pr.yml` and `on.push.yml` workflows kick in on PR and push events, respectively, and call this workflow as a
+# Reusable Workflow.
+#
+# This workflow can be tested independently of the entrypoint flow through the `workflow_dispatch` hook, which adds a
+# button within the UI of the GitHub repository. You can trigger the workflow from here:
+#
+# https://github.com/google/guava/actions/workflows/ci.build.yml
+#
+# ## Inputs
+#
+# See the set of input parameters underneath the `workflow_call` and `workflow_dispatch` hooks for ways this workflow
+# can be controlled when called.
+#
+# ## SLSA Provenance
+#
+# After building Guava in both JRE and Android variants, this workflow will (if enabled) generate provenance material
+# and upload it to an associated release. Learn more about SLSA here: https://slsa.dev.
+
 name: Build
 
 on:

--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -78,15 +78,25 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
       - name: 'Install'
         shell: bash
-        run: ./mvnw --strict-checksums -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
+        run: |
+          ./mvnw \
+            --strict-checksums \
+            -B \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            install \
+            -U \
+            -DskipTests=true \
+            -Dmaven.javadoc.skip=false \
+            -Dgpg.skip \
+            -f $ROOT_POM
       - name: Generate hashes
         shell: bash
         id: hash
@@ -138,10 +148,10 @@ jobs:
           egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           server-id: ${{ inputs.repository }}
           server-username: CI_DEPLOY_USERNAME
@@ -171,10 +181,10 @@ jobs:
           egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
       - name: 'Generate latest docs'

--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -86,7 +86,7 @@ jobs:
           cache: 'maven'
       - name: 'Install'
         shell: bash
-        run: ./mvnw -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
+        run: ./mvnw --strict-checksums -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
       - name: Generate hashes
         shell: bash
         id: hash

--- a/.github/workflows/ci.build.yml
+++ b/.github/workflows/ci.build.yml
@@ -1,0 +1,183 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      provenance:
+        type: boolean
+        description: "Provenance"
+        default: false
+      provenance_publish:
+        type: boolean
+        description: "Publish: Provenance"
+        default: true
+      snapshot:
+        type: boolean
+        description: "Publish: Snapshot"
+        default: false
+      repository:
+        type: string
+        description: "Publish Repository"
+        default: "sonatype-nexus-snapshots"
+
+  workflow_dispatch:
+    inputs:
+      provenance:
+        type: boolean
+        description: "Provenance"
+        default: false
+      provenance_publish:
+        type: boolean
+        description: "Publish: Provenance"
+        default: false
+      snapshot:
+        type: boolean
+        description: "Publish: Snapshot"
+        default: true
+      repository:
+        type: string
+        description: "Publish Repository"
+        default: "sonatype-nexus-snapshots"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: ["JRE", "Android"]
+    name: "Build Guava (${{ matrix.mode }})"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    env:
+      ROOT_POM: ${{ matrix.mode == 'Android' && 'android/pom.xml' || 'pom.xml' }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            api.github.com:443
+            cdn.azul.com:443
+            dl.google.com:443
+            docs.oracle.com:443
+            errorprone.info:443
+            github.com:443
+            objects.githubusercontent.com:443
+            oss.sonatype.org:443
+            repo.maven.apache.org:443
+            services.gradle.org:443
+      - name: 'Check out repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+      - name: 'Set up JDK 11'
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: 'Install'
+        shell: bash
+        run: ./mvnw -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
+      - name: Generate hashes
+        shell: bash
+        id: hash
+        if: matrix.mode == 'JRE'
+        run: |
+          echo "Building SLSA provenance material..."
+          ls guava/target/*.jar guava-gwt/target/*.jar guava-testlib/target/*.jar
+          echo "hashes=$(sha256sum guava/target/*.jar guava-gwt/target/*.jar guava-testlib/target/*.jar | base64 -w0)" >> ./provenance-hashes.txt
+          cat ./provenance-hashes.txt >> "$GITHUB_OUTPUT"
+          echo "Gathered provenance hashes:"
+          cat ./provenance-hashes.txt
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: matrix.mode == 'JRE'
+        with:
+          name: guava-artifacts-${{ matrix.mode == 'Android' && 'android' || 'jre' }}-${{ github.sha }}
+          path: |
+            guava/target/*.jar
+            guava-gwt/target/*.jar
+            guava-testlib/target/*.jar
+            ./provenance-hashes.txt
+          if-no-files-found: warn
+          retention-days: 7
+
+  # Generate SLSA provenance
+  provenance:
+    needs: [build]
+    if: inputs.provenance
+    name: "SLSA Provenance"
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: ${{ inputs.provenance_publish }}
+
+  # Publish snapshot JAR
+  publish_snapshot:
+    name: 'Publish Snapshot'
+    needs: [build, provenance]
+    if: inputs.snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: 'Check out repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: 'Set up JDK 11'
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          server-id: ${{ inputs.repository }}
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          cache: 'maven'
+      - name: "Download artifacts"
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: guava-artifacts-jre-${{ github.sha }}
+      - name: 'Publish'
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+        run: ./util/deploy_snapshot.sh
+
+  generate_docs:
+    permissions:
+      contents: write
+    name: 'Generate Docs'
+    needs: build
+    if: github.event_name == 'push' && github.repository == 'google/guava'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: 'Check out repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: 'Set up JDK 11'
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
+        with:
+          java-version: 11
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: 'Generate latest docs'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./util/update_snapshot_docs.sh

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -1,3 +1,24 @@
+# Guava GitHub CI
+# ---------------------------------------------------------------------------------------------------------------------
+# This is the main CI testsuite on GitHub for the Google Guava project. This workflow is not invoked directly; instead,
+# the `on.pr.yml` and `on.push.yml` workflows kick in on PR and push events, respectively, and call this workflow as a
+# Reusable Workflow.
+#
+# This workflow can be tested independently of the entrypoint flow through the `workflow_dispatch` hook, which adds a
+# button within the UI of the GitHub repository. You can trigger the workflow from here:
+#
+# https://github.com/google/guava/actions/workflows/ci.test.yml
+#
+# ## Inputs
+#
+# See the set of input parameters underneath the `workflow_call` and `workflow_dispatch` hooks for ways this workflow
+# can be controlled when called.
+#
+# ## Multi-OS and Multi-JVM Testing
+#
+# Guava is tested against each LTS release at JDK 8 through JDK 21, on Linux and on Windows (starting at JDK 17), and
+# in Android and JRE flavors.
+
 name: Tests
 
 on:

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -59,10 +59,10 @@ jobs:
           cache: 'maven'
       - name: 'Install'
         shell: bash
-        run: ./mvnw -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
+        run: ./mvnw --strict-checksums -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
       - name: 'Test'
         shell: bash
-        run: ./mvnw -B -P!standard-with-extra-repos verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
+        run: ./mvnw --strict-checksums -B -P!standard-with-extra-repos verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
       - name: 'Print Surefire reports'
         # Note: Normally a step won't run if the job has failed, but this causes it to
         if: ${{ failure() }}

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -59,10 +59,28 @@ jobs:
           cache: 'maven'
       - name: 'Install'
         shell: bash
-        run: ./mvnw --strict-checksums -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -f $ROOT_POM
+        run: |
+          ./mvnw \
+            --strict-checksums \
+            -B \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            install \
+            -U \
+            -DskipTests=true \
+            -Dgpg.skip \
+            -Dmaven.javadoc.skip=true \
+            -f $ROOT_POM
       - name: 'Test'
         shell: bash
-        run: ./mvnw --strict-checksums -B -P!standard-with-extra-repos verify -U -Dmaven.javadoc.skip=true -f $ROOT_POM
+        run: |
+          ./mvnw \
+            --strict-checksums \
+            -B \
+            -P!standard-with-extra-repos \
+            verify \
+            -U \
+            -Dmaven.javadoc.skip=true \
+            -f $ROOT_POM
       - name: 'Print Surefire reports'
         # Note: Normally a step won't run if the job has failed, but this causes it to
         if: ${{ failure() }}

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   workflow_call: {}
@@ -11,7 +11,7 @@ jobs:
   test:
     permissions:
       contents: read  # for actions/checkout to fetch code
-    name: "JDK ${{ matrix.java }} / ${{ matrix.mode }} (${{ matrix.os }})"
+    name: "JDK ${{ matrix.java }} ${{ matrix.mode }} (${{ matrix.os }})"
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -25,6 +25,8 @@ jobs:
             java: 21
             mode: Android
     runs-on: ${{ matrix.os }}
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     env:
       ROOT_POM: ${{ matrix.mode == 'Android' && 'android/pom.xml' || 'pom.xml' }}
     steps:
@@ -71,54 +73,3 @@ jobs:
         shell: bash
         run: util/gradle_integration_tests.sh
 
-  publish_snapshot:
-    name: 'Publish snapshot'
-    needs: test
-    if: github.event_name == 'push' && github.repository == 'google/guava'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-      - name: 'Check out repository'
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: 'Set up JDK 21'
-        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-        with:
-          java-version: 21
-          distribution: 'zulu'
-          server-id: sonatype-nexus-snapshots
-          server-username: CI_DEPLOY_USERNAME
-          server-password: CI_DEPLOY_PASSWORD
-          cache: 'maven'
-      - name: 'Publish'
-        env:
-          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
-          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
-        run: ./util/deploy_snapshot.sh
-
-  generate_docs:
-    permissions:
-      contents: write
-    name: 'Generate latest docs'
-    needs: test
-    if: github.event_name == 'push' && github.repository == 'google/guava'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-      - name: 'Check out repository'
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: 'Set up JDK 21'
-        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-        with:
-          java-version: 21
-          distribution: 'zulu'
-          cache: 'maven'
-      - name: 'Generate latest docs'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./util/update_snapshot_docs.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_call: {}
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -21,14 +17,17 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java: [ 8, 11, 17, 21 ]
-        root-pom: [ 'pom.xml', 'android/pom.xml' ]
+        mode: [ 'JRE', 'Android' ]
         include:
           - os: windows-latest
             java: 21
-            root-pom: pom.xml
+            mode: JRE
+          - os: windows-latest
+            java: 21
+            mode: Android
     runs-on: ${{ matrix.os }}
     env:
-      ROOT_POM: ${{ matrix.root-pom }}
+      ROOT_POM: ${{ matrix.mode == 'Android' && 'android/pom.xml' || 'pom.xml' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ permissions:
 jobs:
   test:
     permissions:
-      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: read  # for actions/checkout to fetch code
-    name: "${{ matrix.root-pom }} on JDK ${{ matrix.java }} on ${{ matrix.os }}"
+    name: "JDK ${{ matrix.java }} / ${{ matrix.mode }} (${{ matrix.os }})"
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -32,12 +31,20 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
-      # Cancel any previous runs for the same branch that are still running.
-      - name: 'Cancel previous runs'
-        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
-        with:
-          access_token: ${{ github.token }}
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            api.github.com:443
+            cdn.azul.com:443
+            dl.google.com:443
+            docs.oracle.com:443
+            errorprone.info:443
+            github.com:443
+            objects.githubusercontent.com:443
+            oss.sonatype.org:443
+            repo.maven.apache.org:443
+            services.gradle.org:443
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
     env:
       ROOT_POM: ${{ matrix.root-pom }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
       # Cancel any previous runs for the same branch that are still running.
       - name: 'Cancel previous runs'
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
@@ -37,9 +41,10 @@ jobs:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
-
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -66,6 +71,10 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'google/guava'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: 'Set up JDK 21'
@@ -91,6 +100,10 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'google/guava'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
       - name: 'Check out repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: 'Set up JDK 21'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,35 +31,48 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.azul.com:443
+            api.github.com:443
+            cdn.azul.com:443
+            dl.google.com:443
+            docs.oracle.com:443
+            errorprone.info:443
+            github.com:443
+            objects.githubusercontent.com:443
+            oss.sonatype.org:443
+            repo.maven.apache.org:443
+            services.gradle.org:443
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
+      - name: 'Set up JDK 21'
+        uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
+        with:
+          java-version: 21
+          distribution: 'zulu'
+          cache: 'maven'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
+        continue-on-error: true
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
-
+      - name: Build Package
+        run: |
+          ./mvnw \
+            --strict-checksums \
+            -B \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            install \
+            -U \
+            -DskipTests=true \
+            -Dmaven.javadoc.skip=true \
+            -f pom.xml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
+        continue-on-error: true
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,7 @@ jobs:
             -U \
             -DskipTests=true \
             -Dmaven.javadoc.skip=true \
+            -Dgpg.skip \
             -f pom.xml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,9 @@
 name: "CodeQL"
 
 on:
+  workflow_call: {}
+  workflow_dispatch: {}
   push:
-    branches: ["master"]
-  pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["master"]
   schedule:
     - cron: "0 0 * * 1"
@@ -14,7 +13,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    name: CodeQL Analysis
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -37,10 +36,8 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+        uses: github/codeql-action/init@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +47,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+        uses: github/codeql-action/autobuild@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -63,6 +60,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+        uses: github/codeql-action/analyze@8a470fddafa5cbb6266ee11b37ef4d8aae19c571 # v3.24.6
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,13 @@
 name: "CodeQL"
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      publish:
+        type: boolean
+        description: "Publish SARIF"
+        default: true
+
   workflow_dispatch: {}
   push:
     branches: ["master"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["master"]
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["java"]
+        # CodeQL supports [ $supported-codeql-languages ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@928ff8c822d966a999092a6a35e32177899afb7c # v2.24.6
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+name: 'Dependency Graph'
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: 'Dependency Graph'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # needed to check out the repository
+      id-token: write  # needed to exchange the graph publish token for an access token
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+      - name: 'Checkout Repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Maven Dependency Tree Dependency Submission
+        uses: advanced-security/maven-dependency-submission-action@bfd2106013da0957cdede0b6c39fb5ca25ae375e # v4.0.2
+        with:
+          token: ${{ secrets.GH_GRAPH_PUBLISH_TOKEN }}
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3
+        continue-on-error: true
+        with:
+          retry-on-snapshot-warnings: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            oss.sonatype.org:443
+            repo.maven.apache.org:443
       - name: 'Checkout Repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Maven Dependency Tree Dependency Submission

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,9 +1,17 @@
 name: 'Dependency Graph'
 on:
-  pull_request: {}
-  push:
-    branches:
-      - master
+  workflow_call:
+    inputs:
+      review:
+        type: boolean
+        description: "Dependency Review"
+        default: false
+  workflow_dispatch:
+    inputs:
+      review:
+        type: boolean
+        description: "Dependency Review"
+        default: false
 
 permissions:
   contents: read
@@ -13,8 +21,8 @@ jobs:
     name: 'Dependency Graph'
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # needed to check out the repository
-      id-token: write  # needed to exchange the graph publish token for an access token
+      contents: write         # needed to post a dependency graph
+      id-token: write         # needed to exchange the graph publish token for an access token
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -23,9 +31,8 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Maven Dependency Tree Dependency Submission
+        continue-on-error: true
         uses: advanced-security/maven-dependency-submission-action@bfd2106013da0957cdede0b6c39fb5ca25ae375e # v4.0.2
-        with:
-          token: ${{ secrets.GH_GRAPH_PUBLISH_TOKEN }}
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3
         continue-on-error: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,16 @@
+# Guava GitHub CI
+# ---------------------------------------------------------------------------------------------------------------------
+# This workflow is called from `on.push.yml` and `on.pr.yml` to operate on Guava's dependency graph:
+#
+# - The dependency graph is calculated from pom.xml files
+# - The graph is then published to GitHub, and associated with the Guava repository
+# - When operating on a PR, Dependency Review can be invoked to check dependency changes
+#
+# ## Inputs
+#
+# See the set of input parameters underneath the `workflow_call` and `workflow_dispatch` hooks for ways this workflow
+# can be controlled when called.
+
 name: 'Dependency Graph'
 on:
   workflow_call:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,18 +1,14 @@
 name: "Validate Gradle Wrapper"
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_call: {}
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
   validation:
-    name: "Validation"
+    name: "Gradle Wrapper Validate"
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,11 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -9,5 +15,11 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
       - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2.1.1

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           persist-credentials: false

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -1,0 +1,46 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: guava-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ## Run main CI build and tests.
+  run-ci:
+    name: "Build & Test"
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      actions: write
+      contents: write
+
+  ## Validate the Gradle Wrapper binary
+  checks-gradle-wrapper:
+    name: "Checks"
+    uses: ./.github/workflows/gradle-wrapper-validation.yml
+
+  ## Publish and check the dependency graph.
+  checks-dependency-graph:
+    name: "Checks"
+    uses: ./.github/workflows/dependency-review.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      review: true
+
+  ## Run CodeQL checks
+  checks-codeql:
+    name: "Checks"
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -1,3 +1,11 @@
+# Guava GitHub CI
+# ---------------------------------------------------------------------------------------------------------------------
+# This is an entrypoint workflow which operates on pull requests; this workflow doesn't do much on its own. Its job is
+# to dispatch `on.build.yml` and check workflows, which can be found in this same directory.
+#
+# PR workflows are slightly different from push workflows (for example, they do not publish snapshots). See the
+# `on.push.yml` workflow. PR and push flows are designed to be invoked separately.
+
 name: PR
 
 on:

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -13,13 +13,27 @@ permissions:
   contents: read
 
 jobs:
-  ## Run main CI build and tests.
-  run-ci:
-    name: "Build & Test"
-    uses: ./.github/workflows/ci.yml
+  ## Build the library and provenance material, but don't publish
+  build:
+    name: "Build"
+    uses: ./.github/workflows/ci.build.yml
     permissions:
       actions: write
       contents: write
+      id-token: write
+    with:
+      provenance: ${{ github.event.pull_request.head.repo.full_name == 'google/guava' }}
+      provenance_publish: false
+      snapshot: false
+
+  ## Run main CI build and tests.
+  test:
+    name: "Tests"
+    uses: ./.github/workflows/ci.test.yml
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
 
   ## Validate the Gradle Wrapper binary
   checks-gradle-wrapper:
@@ -44,3 +58,5 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    with:
+      publish: ${{ github.event.pull_request.head.repo.full_name == 'google/guava' }}

--- a/.github/workflows/on.push.yml
+++ b/.github/workflows/on.push.yml
@@ -1,3 +1,11 @@
+# Guava GitHub CI
+# ---------------------------------------------------------------------------------------------------------------------
+# This is an entrypoint workflow which operates on pushed revisions to Guava; this workflow doesn't do much on its own.
+# Its job is to dispatch `on.build.yml` and check workflows, which can be found in this same directory.
+#
+# PR workflows are slightly different from push workflows (for example, the push workflow publishes snapshots). See the
+# `on.pr.yml` workflow. PR and push flows are designed to be invoked separately.
+
 name: Push
 
 on:

--- a/.github/workflows/on.push.yml
+++ b/.github/workflows/on.push.yml
@@ -15,11 +15,15 @@ permissions:
 jobs:
   ## Run main CI build and tests.
   run-ci:
-    name: "Build & Test"
-    uses: ./.github/workflows/ci.yml
+    name: "Build"
+    uses: ./.github/workflows/ci.build.yml
     permissions:
       actions: write
       contents: write
+      id-token: write
+    with:
+      snapshot: github.repository == 'google/guava'
+      provenance: true
 
   ## Publish and check the dependency graph.
   checks-dependency-graph:

--- a/.github/workflows/on.push.yml
+++ b/.github/workflows/on.push.yml
@@ -1,0 +1,35 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: guava-push-${{ github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ## Run main CI build and tests.
+  run-ci:
+    name: "Build & Test"
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      actions: write
+      contents: write
+
+  ## Publish and check the dependency graph.
+  checks-dependency-graph:
+    name: "Checks"
+    uses: ./.github/workflows/dependency-review.yml
+    permissions:
+      contents: write
+      id-token: write
+
+  ## Validate the Gradle Wrapper binary
+  checks-gradle-wrapper:
+    name: "Checks"
+    uses: ./.github/workflows/gradle-wrapper-validation.yml

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,10 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
       - name: "Checkout code"
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -9,7 +9,7 @@
     <version>HEAD-jre-SNAPSHOT</version>
   </parent>
   <artifactId>guava</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <name>Guava: Google Core Libraries for Java</name>
   <url>https://github.com/google/guava</url>
   <description>
@@ -222,4 +222,86 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>spdx</id>
+      <activation>
+        <jdk>[11,</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <!--
+            @TODO(sgammon): explain
+          -->
+          <plugin>
+            <groupId>org.spdx</groupId>
+            <artifactId>spdx-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-spdx</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>createSPDX</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <useArtifactID>true</useArtifactID>
+              <includeTransitiveDependencies>true</includeTransitiveDependencies>
+              <originator>Organization: Google, LLC</originator>
+              <copyrightText>Copyright (c) 2012-2024, The Guava Authors</copyrightText>
+              <defaultFileCopyright>Copyright (c) 2012-2024, The Guava Authors</defaultFileCopyright>
+              <defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
+              <creators><creator>Organization: Google, LLC</creator></creators>
+              <checksumAlgorithms>
+                <checksumAlgorithm>SHA256</checksumAlgorithm>
+              </checksumAlgorithms>
+            </configuration>
+          </plugin>
+          <!--
+            @TODO(sgammon): explain
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>repack-spdx</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <unzip src="${project.build.directory}/guava-${project.version}.jar" dest="${project.build.directory}/repack"/>
+                    <copy todir="${project.build.directory}/repack/META-INF/spdx">
+                      <fileset dir="${project.build.directory}/site" >
+                        <include name="*.spdx.json"/>
+                      </fileset>
+                    </copy>
+                    <zip basedir="${project.build.directory}/repack" destfile="${project.build.directory}/guava-${project.version}.jar"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!--
+            @TODO(sgammon): explain
+          -->
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-gpg</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,19 @@
         <build>
           <plugins>
             <plugin>
+              <groupId>dev.sigstore</groupId>
+              <artifactId>sigstore-maven-plugin</artifactId>
+              <version>0.4.0</version>
+              <executions>
+                <execution>
+                  <id>sign</id>
+                  <goals>
+                    <goal>sign</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
               <artifactId>maven-gpg-plugin</artifactId>
               <version>3.0.1</version>
               <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
     <otherVariant.version>HEAD-android-SNAPSHOT</otherVariant.version>
     <otherVariant.jvmEnvironment>android</otherVariant.jvmEnvironment>
     <otherVariant.jvmEnvironmentVariantName>android</otherVariant.jvmEnvironmentVariantName>
+    <publishing.repository.snapshots>https://oss.sonatype.org/content/repositories/snapshots/</publishing.repository.snapshots>
+    <publishing.repository.releases>https://oss.sonatype.org/service/local/staging/deploy/maven2/</publishing.repository.releases>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>
@@ -279,12 +281,12 @@
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>${publishing.repository.snapshots}</url>
     </snapshotRepository>
     <repository>
       <id>sonatype-nexus-staging</id>
       <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>${publishing.repository.releases}</url>
     </repository>
     <site>
       <id>guava-site</id>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,20 @@
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.4.0</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.0.1</version>
+        </plugin>
+        <plugin>
+          <groupId>dev.sigstore</groupId>
+          <artifactId>sigstore-maven-plugin</artifactId>
+          <version>0.4.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.spdx</groupId>
+          <artifactId>spdx-maven-plugin</artifactId>
+          <version>0.7.3</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -331,7 +345,6 @@
             <plugin>
               <groupId>dev.sigstore</groupId>
               <artifactId>sigstore-maven-plugin</artifactId>
-              <version>0.4.0</version>
               <executions>
                 <execution>
                   <id>sign</id>
@@ -343,7 +356,6 @@
             </plugin>
             <plugin>
               <artifactId>maven-gpg-plugin</artifactId>
-              <version>3.0.1</version>
               <executions>
                 <execution>
                   <id>sign-artifacts</id>


### PR DESCRIPTION
Part 4 of PR testing.

## Summary

Applies updates to GHA CI, and refactors into [Reusable Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows). Hardens supply chain security for Guava both in CI and release.

### Enclosed features

- Ran [StepSecurity](https://stepsecurity.io) on current jobs
- Added support for [SLSA Provenance](https://slsa.dev) during the release flow
- Added support for [Sigstore](https://sigstore.dev) signing during the release flow
- Added support for the [Github Dependency Graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) and [Dependency Review](https://github.com/actions/dependency-review-action)
- Added support for scans via [CodeQL](https://codeql.github.com/)
- All CI builds and tests now appear on one screen

### Changelog

- **chore(ci): apply hardening to ci jobs**
- chore: apply 'Harden Runner' auditing to all ci tasks
- chore: apply `persist-credentials: false` to checkout tasks
- chore: publish dependency graph and add dependency review check
- chore: add codeql scan job (temp)
- chore: bump `actions/checkout` → `4.1.1`
- chore: bump `actions/dependency-review-action` → `4.1.3`
- **chore(ci): refactor into reusable workflows**
- chore: move ci jobs to `workflow_call` trigger
- chore: add entrypoint jobs for PR and Push events
- chore: cleanup permissions and dispatch checks/tests
- **chore(ci): switch to enforced hardening mode**
- chore: gather and apply network endpoints for each job
- chore: move to `block` mode for `egress-policy` in `step-security/harden-runner`
- **feat(ci): slsa provenance support**
- feat: add slsa support to build workflow
- chore: split `test` into `build` and `test` workflows
- chore: use new workflows (build/test) from push/pr triggers
- **chore(build): parameterize deploy repositories**
- **chore: add sigstore plugin to build**
- **chore: add `--strict-checksums` flag to `mvnw` calls in ci**

### Action updates

Bumps [actions/checkout](https://github.com/actions/checkout) from 3.6.0 to 4.1.1.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v3.6.0...b4ffde65f46336ab88eb53be808477a3936bae11)

Bumps [actions/dependency-review-action](https://github.com/actions/dependency-review-action) from 2.5.1 to 4.1.3.
- [Release notes](https://github.com/actions/dependency-review-action/releases)
- [Commits](https://github.com/actions/dependency-review-action/compare/0efb1d1d84fc9633afcdaad14c485cbbc90ef46c...9129d7d40b8c12c1ed0f60400d00c92d437adcce)